### PR TITLE
Minor changes to data checks

### DIFF
--- a/bayreg/linear_model.py
+++ b/bayreg/linear_model.py
@@ -162,7 +162,7 @@ class ConjugateBayesianLinearRegression:
         elif pred.ndim == 1:
             pred = pred.reshape(-1, 1)
         else:
-            pred = pred.reshape(self.num_obs, -1)
+            pass
 
         if np.any(np.isnan(pred)):
             raise ValueError('The predictors array cannot have null values.')
@@ -401,12 +401,15 @@ class ConjugateBayesianLinearRegression:
         else:
             x = predictors.copy()
             # Check and prepare predictor data
-            # -- data types match across instantiated predictors and predictors
+            # -- check if data types match across instantiated predictors and predictors
+            if not isinstance(predictors, self.predictors_type):
+                warnings.warn('Object type for predictors does not match the predictors '
+                              'object type instantiated with ConjugateBayesianLinearRegression.')
             # -- if Pandas type, grab index and column names
             if isinstance(predictors, (pd.Series, pd.DataFrame)):
                 if not isinstance(predictors.index, type(self.response_index)):
-                    raise TypeError('Index type for predictors does not match the predictors '
-                                    'index type instantiated with ConjugateBayesianLinearRegression.')
+                    warnings.warn('Index type for predictors does not match the predictors '
+                                  'index type instantiated with ConjugateBayesianLinearRegression.')
 
                 if isinstance(predictors, pd.Series):
                     predictors_names = [predictors.name]


### PR DESCRIPTION
- If predictors is a 2-dimensional array, reshaping is no longer done. It will automatically be assumed that the data is shaped in a way that conforms with the response. And if the assumptions are broken, exceptions will be raised in linear_model.py.
- If the data type for predictors passed to ConjugateBayesianLinearRegression.predict() is not the same as the type passed to __init__(), then a warning will be raised.
- If the data type for predictors passed to ConjugateBayesianLinearRegression.predict() and __init__() are Pandas Series or DataFrames, and if the index types do not match, a warning will be raised.